### PR TITLE
Update sketch_{{cookiecutter.sketch_slug}}.py

### DIFF
--- a/{{cookiecutter.sketch_name}}/sketch_{{cookiecutter.sketch_slug}}.py
+++ b/{{cookiecutter.sketch_name}}/sketch_{{cookiecutter.sketch_slug}}.py
@@ -10,7 +10,7 @@ class {{cookiecutter.class_name}}(vsketch.SketchClass):
         vsk.scale("{{cookiecutter.preferred_unit}}")
 
         # implement your sketch here
-        # vsk.circle(0, 0, self.radius(), mode="radius")
+        # vsk.circle(0, 0, self.radius, mode="radius")
 
     def finalize(self, vsk: vsketch.Vsketch) -> None:
         vsk.vpype("linemerge linesimplify reloop linesort")


### PR DESCRIPTION
Changed `# vsk.circle(0, 0, self.radius(), mode="radius")` to `# vsk.circle(0, 0, self.radius, mode="radius")` to fix the `TypeError: 'float' object is not callable` error when trying out the example text in the vsketch init example sketch.